### PR TITLE
Show cid error messages to user

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,13 @@
     <h1 class='aqua fw2 montserrat dib ma0 pv2 ph1 v-mid fr f3 lh-copy'>CID inspector</h1>
   </header>
   <section class='pv4 pl2 pl5-l'>
-    <div class='pt2 measure-wide cf'>
+    <div class='pt2 measure-wide cf pr2 pr0-l'>
       <a class='gray hover-aqua link underline fr' href="https://github.com/ipld/cid">Spec</a>
       <label for="input-cid" class='db pb2 w-100 fw2 tracked ttu f5 teal'>CID</label>
-      <input id="input-cid" type="text" class='db w-100 ph1 pv2 monospace'>
+      <input id="input-cid" type="text" class='db w-100 ph1 pv2 monospace input-reset ba b--black-20 border-box' />
     </div>
-    <div class='pt4'>
+    <small id="input-error" class="db yellow f6 pt1 overflow-x-auto" style="opacity: 0; min-height:20px;"></small>
+    <div class='pt3'>
       <label class='db'>
         <a class='fw2 tracked ttu f5 teal-muted hover-aqua link' href='https://github.com/ipld/cid#human-readable-cids'>
           Human readable CID

--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const multicodecOutput = document.querySelector('#multicodec')
   const multibaseOutput = document.querySelector('#multibase')
   const humanReadableCidOutput = document.querySelector('#hr-cid')
+  const errorOutput = document.querySelector('#input-error')
+
+  function clearErrorOutput () {
+    errorOutput.innerText = ''
+    errorOutput.style.opacity = 0
+  }
 
   function setOutput (output, value) {
     window.location.hash = value
@@ -64,8 +70,15 @@ document.addEventListener('DOMContentLoaded', () => {
       multibaseOutput.innerHTML = toDefinitionList({code: data.multibase.code, name: data.multibase.name})
       multicodecOutput.innerHTML = toDefinitionList({code: data.multicodec.code, name: data.multicodec.name})
       multihashOutput.innerHTML = toDefinitionList({code: data.multihash.code, name: data.multihash.name, bits: data.multihash.length * 8})
+      clearErrorOutput()
     } catch (err) {
-      console.log(err)
+      if (!value) {
+        clearErrorOutput()
+      } else {
+        console.log(err.message || err)
+        errorOutput.innerText = err.message || err
+        errorOutput.style.opacity = 1
+      }
     }
   }
   if (input.value) {


### PR DESCRIPTION
The error messages are good, so show them to the user to help them correct their unhealthy CID.

Also fix the layout on mobile. Parcel has some super aggressive minification, which removevs the input elements type!? Anyway, that meant border-box sizing wasn't being applied when deployed, so we'd end up with a horizontal scrollbar on mobile. This tool isn't gonna be used on phones so much, but that was like the second bit of feedback i got on it so thanks @richsilv. 😉

Fixes #5

<img width="375" src="https://user-images.githubusercontent.com/58871/36490620-8cf7e394-1720-11e8-85e7-e190cf12f0b4.png" />

