### PR TITLE
always show base32cidv1 version

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,14 @@
       </label>
       <div class='f5 sans-serif ma0 fw4 pt2'id="multihash"></div>
     </div>
+    <div class='pt4'>
+      <label class='dib'>
+        <a class='db pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/ipfs/go-ipfs/issues/4143">
+          Base32 CIDv1
+        </a>
+      </label>
+      <div class='f5 sans-serif ma0 fw4 pt2'id="base32cidv1"></div>
+    </div>
   </section>
   <footer class='mt2 pv2 ph2 ph3-l bt b--light-gray'>
     <a href="https://multiformats.io/" title='Multiformats' class='dib v-mid'>

--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ function decodeCidV0 (value, cid) {
   }
 }
 
+function toBase32(value) {
+  var cid = new CID(value)
+  return cid.toV1().toBaseEncodedString('base32')
+}
+
 function decodeCidV1 (value, cid) {
   return {
     cid,
@@ -52,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const multihashOutput = document.querySelector('#multihash')
   const multicodecOutput = document.querySelector('#multicodec')
   const multibaseOutput = document.querySelector('#multibase')
+  const base32CidV1Output = document.querySelector('#base32cidv1')
   const humanReadableCidOutput = document.querySelector('#hr-cid')
   const errorOutput = document.querySelector('#input-error')
 
@@ -70,6 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
       multibaseOutput.innerHTML = toDefinitionList({code: data.multibase.code, name: data.multibase.name})
       multicodecOutput.innerHTML = toDefinitionList({code: data.multicodec.code, name: data.multicodec.name})
       multihashOutput.innerHTML = toDefinitionList({code: data.multihash.code, name: data.multihash.name, bits: data.multihash.length * 8})
+      base32CidV1Output.innerHTML = toBase32(value.trim())
       clearErrorOutput()
     } catch (err) {
       if (!value) {


### PR DESCRIPTION
This will display a base32 cidv1 with each inspection of a hash.

Context: https://github.com/ipfs/go-ipfs/issues/4143 and https://github.com/ipfs/developer-meetings/pull/16

![b32](https://user-images.githubusercontent.com/28153/42300907-8037a602-7fc7-11e8-8511-e48ec8b4ddc9.png)

Requesting a new release of the site if possible after merging, thanks!